### PR TITLE
Fixed null to string type issue in Role struct

### DIFF
--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -143,7 +143,7 @@ type Policy struct {
 type Role struct {
 	ID                  string    `json:"id" db:"id"`
 	Name                string    `json:"name" db:"name"`
-	Description         string    `json:"description" db:"description"`
+	Description         *string    `json:"description" db:"description"`
 	OrganizationID      string    `json:"organization_id" db:"organization_id"`
 	RoleType            string    `json:"role_type" db:"role_type"`
 	MaxSessionDuration  string    `json:"max_session_duration" db:"max_session_duration"`
@@ -152,11 +152,11 @@ type Role struct {
 	Tags                string    `json:"tags" db:"tags"`                             // JSONB as string
 	IsSystemRole        bool      `json:"is_system_role" db:"is_system_role"`
 	Path                string    `json:"path" db:"path"`
-	PermissionsBoundary string    `json:"permissions_boundary" db:"permissions_boundary"`
+	PermissionsBoundary *string    `json:"permissions_boundary" db:"permissions_boundary"`
 	Status              string    `json:"status" db:"status"`
 	CreatedAt           time.Time `json:"created_at" db:"created_at"`
-	UpdatedAt           time.Time `json:"updated_at" db:"updated_at"`
-	DeletedAt           time.Time `json:"deleted_at" db:"deleted_at"`
+	UpdatedAt           *time.Time `json:"updated_at" db:"updated_at"`
+	DeletedAt           *time.Time `json:"deleted_at" db:"deleted_at"`
 }
 
 // RolePolicy represents the many-to-many relationship between roles and policies


### PR DESCRIPTION
List organization not working,
Fix:
updated the Organization struct in internal/models/models.go to use pointers for nullable fields:
PermissionsBoundary:          string -> *string
Description:                          string -> *string
UpdatedAt:                           time.Time -> *time.Time
DeletedAt:                            time.Time -> *time.Time

This allows the application to correctly handle NULL values from the database.