### PR TITLE
Add proper logging for session cache failures

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -124,7 +124,7 @@ func main() {
 	v1 := api.Group("/v1")
 
 	// Initialize services
-	auditQueries := queries.New(db, redis).Audit
+	auditQueries := queries.New(db, redis, appLogger).Audit
 	auditService := services.NewAuditService(auditQueries, appLogger)
 	auditService.Start(context.Background())
 	defer auditService.Stop()

--- a/internal/handlers/content_handler.go
+++ b/internal/handlers/content_handler.go
@@ -24,7 +24,7 @@ type ContentHandler struct {
 }
 
 func NewContentHandler(db *database.DB, redis *redis.Client, logger *logger.Logger) *ContentHandler {
-	return &ContentHandler{db: db, redis: redis, logger: logger, queries: queries.New(db, redis)}
+	return &ContentHandler{db: db, redis: redis, logger: logger, queries: queries.New(db, redis, logger)}
 }
 
 // ── Helper: per-item authorization ─────────────────────────────────────

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -28,7 +28,7 @@ type GroupHandler struct {
 }
 
 func NewGroupHandler(db *database.DB, redis *redis.Client, logger *logger.Logger) *GroupHandler {
-	return &GroupHandler{db: db, redis: redis, logger: logger, queries: queries.New(db, redis)}
+	return &GroupHandler{db: db, redis: redis, logger: logger, queries: queries.New(db, redis, logger)}
 }
 
 // ListGroups lists groups with optional filtering by organization
@@ -409,7 +409,7 @@ type ResourceHandler struct {
 }
 
 func NewResourceHandler(db *database.DB, redis *redis.Client, logger *logger.Logger) *ResourceHandler {
-	return &ResourceHandler{db: db, redis: redis, logger: logger, queries: queries.New(db, redis)}
+	return &ResourceHandler{db: db, redis: redis, logger: logger, queries: queries.New(db, redis, logger)}
 }
 
 // ListResources lists resources
@@ -940,7 +940,7 @@ func NewPolicyHandler(db *database.DB, redis *redis.Client, logger *logger.Logge
 		db:      db,
 		redis:   redis,
 		logger:  logger,
-		queries: queries.New(db, redis),
+		queries: queries.New(db, redis, logger),
 		audit:   audit,
 		authz:   authz,
 	}
@@ -1803,7 +1803,7 @@ func NewRoleHandler(db *database.DB, redis *redis.Client, logger *logger.Logger)
 		db:      db,
 		redis:   redis,
 		logger:  logger,
-		queries: queries.New(db, redis),
+		queries: queries.New(db, redis, logger),
 	}
 }
 
@@ -2579,7 +2579,7 @@ func NewSessionHandler(db *database.DB, redis *redis.Client, logger *logger.Logg
 		db:      db,
 		redis:   redis,
 		logger:  logger,
-		queries: queries.New(db, redis),
+		queries: queries.New(db, redis, logger),
 	}
 }
 

--- a/internal/handlers/organization.go
+++ b/internal/handlers/organization.go
@@ -28,7 +28,7 @@ type PublicOrganization struct {
 }
 
 func NewOrganizationHandler(db *database.DB, redis *redis.Client, logger *logger.Logger) *OrganizationHandler {
-	return &OrganizationHandler{db: db, redis: redis, logger: logger, queries: queries.New(db, redis)}
+	return &OrganizationHandler{db: db, redis: redis, logger: logger, queries: queries.New(db, redis, logger)}
 }
 
 // SetCORS injects the DynamicCORS reference so origin management endpoints

--- a/internal/queries/audit_queries.go
+++ b/internal/queries/audit_queries.go
@@ -10,6 +10,7 @@ import (
 	"github.com/redis/go-redis/v9"
 	"github.com/the-monkeys/monkeys-identity/internal/database"
 	"github.com/the-monkeys/monkeys-identity/internal/models"
+	"github.com/the-monkeys/monkeys-identity/pkg/logger"
 )
 
 // AuditQueries defines all audit and compliance database operations
@@ -39,22 +40,23 @@ type AuditQueries interface {
 }
 
 type auditQueries struct {
-	db    *database.DB
-	redis *redis.Client
-	tx    *sql.Tx
-	ctx   context.Context
+	db     *database.DB
+	redis  *redis.Client
+	logger *logger.Logger
+	tx     *sql.Tx
+	ctx    context.Context
 }
 
-func NewAuditQueries(db *database.DB, redis *redis.Client) AuditQueries {
-	return &auditQueries{db: db, redis: redis, ctx: context.Background()}
+func NewAuditQueries(db *database.DB, redis *redis.Client, logger *logger.Logger) AuditQueries {
+	return &auditQueries{db: db, redis: redis, logger: logger, ctx: context.Background()}
 }
 
 func (q *auditQueries) WithTx(tx *sql.Tx) AuditQueries {
-	return &auditQueries{db: q.db, redis: q.redis, tx: tx, ctx: q.ctx}
+	return &auditQueries{db: q.db, redis: q.redis, logger: q.logger, tx: tx, ctx: q.ctx}
 }
 
 func (q *auditQueries) WithContext(ctx context.Context) AuditQueries {
-	return &auditQueries{db: q.db, redis: q.redis, tx: q.tx, ctx: ctx}
+	return &auditQueries{db: q.db, redis: q.redis, logger: q.logger, tx: q.tx, ctx: ctx}
 }
 
 // getDB returns the appropriate database connection (transaction or regular)

--- a/internal/queries/auth.go
+++ b/internal/queries/auth.go
@@ -10,6 +10,7 @@ import (
 	"github.com/redis/go-redis/v9"
 	"github.com/the-monkeys/monkeys-identity/internal/database"
 	"github.com/the-monkeys/monkeys-identity/internal/models"
+	"github.com/the-monkeys/monkeys-identity/pkg/logger"
 )
 
 // AuthQueries defines all authentication-related database operations
@@ -52,41 +53,45 @@ type AuthQueries interface {
 
 // authQueries implements AuthQueries
 type authQueries struct {
-	db    *database.DB
-	redis *redis.Client
-	tx    *sql.Tx
-	ctx   context.Context
+	db     *database.DB
+	redis  *redis.Client
+	logger *logger.Logger
+	tx     *sql.Tx
+	ctx    context.Context
 }
 
 // ErrOrganizationNotFound is returned when a referenced organization cannot be located
 var ErrOrganizationNotFound = errors.New("organization not found")
 
 // NewAuthQueries creates a new AuthQueries instance
-func NewAuthQueries(db *database.DB, redis *redis.Client) AuthQueries {
+func NewAuthQueries(db *database.DB, redis *redis.Client, logger *logger.Logger) AuthQueries {
 	return &authQueries{
-		db:    db,
-		redis: redis,
-		ctx:   context.Background(),
+		db:     db,
+		redis:  redis,
+		logger: logger,
+		ctx:    context.Background(),
 	}
 }
 
 // WithTx returns a new AuthQueries instance that will run all SQL queries within a transaction
 func (q *authQueries) WithTx(tx *sql.Tx) AuthQueries {
 	return &authQueries{
-		db:    q.db,
-		redis: q.redis,
-		tx:    tx,
-		ctx:   q.ctx,
+		db:     q.db,
+		redis:  q.redis,
+		logger: q.logger,
+		tx:     tx,
+		ctx:    q.ctx,
 	}
 }
 
 // WithContext returns a new AuthQueries instance with context
 func (q *authQueries) WithContext(ctx context.Context) AuthQueries {
 	return &authQueries{
-		db:    q.db,
-		redis: q.redis,
-		tx:    q.tx,
-		ctx:   ctx,
+		db:     q.db,
+		redis:  q.redis,
+		logger: q.logger,
+		tx:     q.tx,
+		ctx:    ctx,
 	}
 }
 

--- a/internal/queries/content_queries.go
+++ b/internal/queries/content_queries.go
@@ -10,6 +10,7 @@ import (
 	"github.com/redis/go-redis/v9"
 	"github.com/the-monkeys/monkeys-identity/internal/database"
 	"github.com/the-monkeys/monkeys-identity/internal/models"
+	"github.com/the-monkeys/monkeys-identity/pkg/logger"
 )
 
 // ── Interface ──────────────────────────────────────────────────────────
@@ -42,22 +43,23 @@ type ContentQueries interface {
 // ── Implementation ─────────────────────────────────────────────────────
 
 type contentQueries struct {
-	db    *database.DB
-	redis *redis.Client
-	tx    *sql.Tx
-	ctx   context.Context
+	db     *database.DB
+	redis  *redis.Client
+	logger *logger.Logger
+	tx     *sql.Tx
+	ctx    context.Context
 }
 
-func NewContentQueries(db *database.DB, redis *redis.Client) ContentQueries {
-	return &contentQueries{db: db, redis: redis, ctx: context.Background()}
+func NewContentQueries(db *database.DB, redis *redis.Client, logger *logger.Logger) ContentQueries {
+	return &contentQueries{db: db, redis: redis, logger: logger, ctx: context.Background()}
 }
 
 func (q *contentQueries) WithTx(tx *sql.Tx) ContentQueries {
-	return &contentQueries{db: q.db, redis: q.redis, tx: tx, ctx: q.ctx}
+	return &contentQueries{db: q.db, redis: q.redis, logger: q.logger, tx: tx, ctx: q.ctx}
 }
 
 func (q *contentQueries) WithContext(ctx context.Context) ContentQueries {
-	return &contentQueries{db: q.db, redis: q.redis, tx: q.tx, ctx: ctx}
+	return &contentQueries{db: q.db, redis: q.redis, logger: q.logger, tx: q.tx, ctx: ctx}
 }
 
 func (q *contentQueries) conn() DBTX {

--- a/internal/queries/global_settings_queries.go
+++ b/internal/queries/global_settings_queries.go
@@ -8,6 +8,7 @@ import (
 	"github.com/redis/go-redis/v9"
 	"github.com/the-monkeys/monkeys-identity/internal/database"
 	"github.com/the-monkeys/monkeys-identity/internal/models"
+	"github.com/the-monkeys/monkeys-identity/pkg/logger"
 )
 
 type GlobalSettingsQueries interface {
@@ -19,38 +20,42 @@ type GlobalSettingsQueries interface {
 }
 
 type globalSettingsQueries struct {
-	db    *database.DB
-	tx    *sql.Tx
-	ctx   context.Context
-	redis *redis.Client
+	db     *database.DB
+	tx     *sql.Tx
+	ctx    context.Context
+	redis  *redis.Client
+	logger *logger.Logger
 }
 
 // NewGlobalSettingsQueries creates a new GlobalSettingsQueries instance
-func NewGlobalSettingsQueries(db *database.DB, redis *redis.Client) GlobalSettingsQueries {
+func NewGlobalSettingsQueries(db *database.DB, redis *redis.Client, logger *logger.Logger) GlobalSettingsQueries {
 	return &globalSettingsQueries{
-		db:    db,
-		ctx:   context.Background(),
-		redis: redis,
+		db:     db,
+		ctx:    context.Background(),
+		redis:  redis,
+		logger: logger,
 	}
 }
 
 // WithTx returns a new GlobalSettingsQueries instance that will run all SQL queries within a transaction
 func (q *globalSettingsQueries) WithTx(tx *sql.Tx) GlobalSettingsQueries {
 	return &globalSettingsQueries{
-		db:    q.db,
-		tx:    tx,
-		ctx:   q.ctx,
-		redis: q.redis,
+		db:     q.db,
+		tx:     tx,
+		ctx:    q.ctx,
+		redis:  q.redis,
+		logger: q.logger,
 	}
 }
 
 // WithContext returns a new GlobalSettingsQueries instance with context
 func (q *globalSettingsQueries) WithContext(ctx context.Context) GlobalSettingsQueries {
 	return &globalSettingsQueries{
-		db:    q.db,
-		tx:    q.tx,
-		ctx:   ctx,
-		redis: q.redis,
+		db:     q.db,
+		tx:     q.tx,
+		ctx:    ctx,
+		redis:  q.redis,
+		logger: q.logger,
 	}
 }
 

--- a/internal/queries/group_queries.go
+++ b/internal/queries/group_queries.go
@@ -12,6 +12,7 @@ import (
 	"github.com/redis/go-redis/v9"
 	"github.com/the-monkeys/monkeys-identity/internal/database"
 	"github.com/the-monkeys/monkeys-identity/internal/models"
+	"github.com/the-monkeys/monkeys-identity/pkg/logger"
 )
 
 // ErrGroupNameConflict is returned when attempting to create/update a group with a name that already exists in the organization
@@ -39,22 +40,23 @@ type GroupQueries interface {
 }
 
 type groupQueries struct {
-	db    *database.DB
-	redis *redis.Client
-	tx    *sql.Tx
-	ctx   context.Context
+	db     *database.DB
+	redis  *redis.Client
+	logger *logger.Logger
+	tx     *sql.Tx
+	ctx    context.Context
 }
 
-func NewGroupQueries(db *database.DB, redis *redis.Client) GroupQueries {
-	return &groupQueries{db: db, redis: redis, ctx: context.Background()}
+func NewGroupQueries(db *database.DB, redis *redis.Client, logger *logger.Logger) GroupQueries {
+	return &groupQueries{db: db, redis: redis, logger: logger, ctx: context.Background()}
 }
 
 func (q *groupQueries) WithTx(tx *sql.Tx) GroupQueries {
-	return &groupQueries{db: q.db, redis: q.redis, tx: tx, ctx: q.ctx}
+	return &groupQueries{db: q.db, redis: q.redis, logger: q.logger, tx: tx, ctx: q.ctx}
 }
 
 func (q *groupQueries) WithContext(ctx context.Context) GroupQueries {
-	return &groupQueries{db: q.db, redis: q.redis, tx: q.tx, ctx: ctx}
+	return &groupQueries{db: q.db, redis: q.redis, logger: q.logger, tx: q.tx, ctx: ctx}
 }
 
 // helper selection list

--- a/internal/queries/oidc_queries.go
+++ b/internal/queries/oidc_queries.go
@@ -9,6 +9,7 @@ import (
 	"github.com/redis/go-redis/v9"
 	"github.com/the-monkeys/monkeys-identity/internal/database"
 	"github.com/the-monkeys/monkeys-identity/internal/models"
+	"github.com/the-monkeys/monkeys-identity/pkg/logger"
 )
 
 type OIDCQueries interface {
@@ -29,35 +30,39 @@ type OIDCQueries interface {
 }
 
 type oidcQueries struct {
-	db    *database.DB
-	redis *redis.Client
-	ctx   context.Context
-	tx    *sql.Tx
+	db     *database.DB
+	redis  *redis.Client
+	logger *logger.Logger
+	ctx    context.Context
+	tx     *sql.Tx
 }
 
-func NewOIDCQueries(db *database.DB, redis *redis.Client) OIDCQueries {
+func NewOIDCQueries(db *database.DB, redis *redis.Client, logger *logger.Logger) OIDCQueries {
 	return &oidcQueries{
-		db:    db,
-		redis: redis,
-		ctx:   context.Background(),
+		db:     db,
+		redis:  redis,
+		logger: logger,
+		ctx:    context.Background(),
 	}
 }
 
 func (q *oidcQueries) WithTx(tx *sql.Tx) OIDCQueries {
 	return &oidcQueries{
-		db:    q.db,
-		redis: q.redis,
-		ctx:   q.ctx,
-		tx:    tx,
+		db:     q.db,
+		redis:  q.redis,
+		logger: q.logger,
+		ctx:    q.ctx,
+		tx:     tx,
 	}
 }
 
 func (q *oidcQueries) WithContext(ctx context.Context) OIDCQueries {
 	return &oidcQueries{
-		db:    q.db,
-		redis: q.redis,
-		ctx:   ctx,
-		tx:    q.tx,
+		db:     q.db,
+		redis:  q.redis,
+		logger: q.logger,
+		ctx:    ctx,
+		tx:     q.tx,
 	}
 }
 

--- a/internal/queries/organization_queries.go
+++ b/internal/queries/organization_queries.go
@@ -10,6 +10,7 @@ import (
 	"github.com/redis/go-redis/v9"
 	"github.com/the-monkeys/monkeys-identity/internal/database"
 	"github.com/the-monkeys/monkeys-identity/internal/models"
+	"github.com/the-monkeys/monkeys-identity/pkg/logger"
 )
 
 // OrganizationQueries defines all organization management database operations
@@ -37,22 +38,23 @@ type OrganizationQueries interface {
 }
 
 type organizationQueries struct {
-	db    *database.DB
-	redis *redis.Client
-	tx    *sql.Tx
-	ctx   context.Context
+	db     *database.DB
+	redis  *redis.Client
+	logger *logger.Logger
+	tx     *sql.Tx
+	ctx    context.Context
 }
 
-func NewOrganizationQueries(db *database.DB, redis *redis.Client) OrganizationQueries {
-	return &organizationQueries{db: db, redis: redis, ctx: context.Background()}
+func NewOrganizationQueries(db *database.DB, redis *redis.Client, logger *logger.Logger) OrganizationQueries {
+	return &organizationQueries{db: db, redis: redis, logger: logger, ctx: context.Background()}
 }
 
 func (q *organizationQueries) WithTx(tx *sql.Tx) OrganizationQueries {
-	return &organizationQueries{db: q.db, redis: q.redis, tx: tx, ctx: q.ctx}
+	return &organizationQueries{db: q.db, redis: q.redis, logger: q.logger, tx: tx, ctx: q.ctx}
 }
 
 func (q *organizationQueries) WithContext(ctx context.Context) OrganizationQueries {
-	return &organizationQueries{db: q.db, redis: q.redis, tx: q.tx, ctx: ctx}
+	return &organizationQueries{db: q.db, redis: q.redis, logger: q.logger, tx: q.tx, ctx: ctx}
 }
 
 // ListOrganizations returns paginated organizations (excluding deleted).

--- a/internal/queries/policy_queries.go
+++ b/internal/queries/policy_queries.go
@@ -13,6 +13,7 @@ import (
 	"github.com/redis/go-redis/v9"
 	"github.com/the-monkeys/monkeys-identity/internal/database"
 	"github.com/the-monkeys/monkeys-identity/internal/models"
+	"github.com/the-monkeys/monkeys-identity/pkg/logger"
 )
 
 // PolicyQueries defines all policy management database operations
@@ -134,22 +135,23 @@ type EffectivePermission struct {
 }
 
 type policyQueries struct {
-	db    *database.DB
-	redis *redis.Client
-	tx    *sql.Tx
-	ctx   context.Context
+	db     *database.DB
+	redis  *redis.Client
+	logger *logger.Logger
+	tx     *sql.Tx
+	ctx    context.Context
 }
 
-func NewPolicyQueries(db *database.DB, redis *redis.Client) PolicyQueries {
-	return &policyQueries{db: db, redis: redis, ctx: context.Background()}
+func NewPolicyQueries(db *database.DB, redis *redis.Client, logger *logger.Logger) PolicyQueries {
+	return &policyQueries{db: db, redis: redis, logger: logger, ctx: context.Background()}
 }
 
 func (q *policyQueries) WithTx(tx *sql.Tx) PolicyQueries {
-	return &policyQueries{db: q.db, redis: q.redis, tx: tx, ctx: q.ctx}
+	return &policyQueries{db: q.db, redis: q.redis, logger: q.logger, tx: tx, ctx: q.ctx}
 }
 
 func (q *policyQueries) WithContext(ctx context.Context) PolicyQueries {
-	return &policyQueries{db: q.db, redis: q.redis, tx: q.tx, ctx: ctx}
+	return &policyQueries{db: q.db, redis: q.redis, logger: q.logger, tx: q.tx, ctx: ctx}
 }
 
 func (q *policyQueries) ListPolicies(params ListParams, organizationID string) (*ListResult[*models.Policy], error) {

--- a/internal/queries/queries.go
+++ b/internal/queries/queries.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/redis/go-redis/v9"
 	"github.com/the-monkeys/monkeys-identity/internal/database"
+	"github.com/the-monkeys/monkeys-identity/pkg/logger"
 )
 
 // Queries holds all query interfaces
@@ -24,25 +25,27 @@ type Queries struct {
 	Content        ContentQueries
 	db             *database.DB
 	redis          *redis.Client
+	logger         *logger.Logger
 }
 
 // New creates a new Queries instance with all query implementations
-func New(db *database.DB, redis *redis.Client) *Queries {
+func New(db *database.DB, redis *redis.Client, logger *logger.Logger) *Queries {
 	return &Queries{
-		Auth:           NewAuthQueries(db, redis),
-		User:           NewUserQueries(db, redis),
-		Organization:   NewOrganizationQueries(db, redis),
-		Group:          NewGroupQueries(db, redis),
-		Resource:       NewResourceQueries(db, redis),
-		Policy:         NewPolicyQueries(db, redis),
-		Role:           NewRoleQueries(db, redis),
-		Session:        NewSessionQueries(db, redis),
-		Audit:          NewAuditQueries(db, redis),
-		GlobalSettings: NewGlobalSettingsQueries(db, redis),
-		OIDC:           NewOIDCQueries(db, redis),
-		Content:        NewContentQueries(db, redis),
+		Auth:           NewAuthQueries(db, redis, logger),
+		User:           NewUserQueries(db, redis, logger),
+		Organization:   NewOrganizationQueries(db, redis, logger),
+		Group:          NewGroupQueries(db, redis, logger),
+		Resource:       NewResourceQueries(db, redis, logger),
+		Policy:         NewPolicyQueries(db, redis, logger),
+		Role:           NewRoleQueries(db, redis, logger),
+		Session:        NewSessionQueries(db, redis, logger),
+		Audit:          NewAuditQueries(db, redis, logger),
+		GlobalSettings: NewGlobalSettingsQueries(db, redis, logger),
+		OIDC:           NewOIDCQueries(db, redis, logger),
+		Content:        NewContentQueries(db, redis, logger),
 		db:             db,
 		redis:          redis,
+		logger:         logger,
 	}
 }
 
@@ -63,6 +66,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		Content:        q.Content.WithTx(tx),
 		db:             q.db,
 		redis:          q.redis,
+		logger:         q.logger,
 	}
 }
 
@@ -83,6 +87,7 @@ func (q *Queries) WithContext(ctx context.Context) *Queries {
 		Content:        q.Content.WithContext(ctx),
 		db:             q.db,
 		redis:          q.redis,
+		logger:         q.logger,
 	}
 }
 

--- a/internal/queries/resource_queries.go
+++ b/internal/queries/resource_queries.go
@@ -10,6 +10,7 @@ import (
 	"github.com/redis/go-redis/v9"
 	"github.com/the-monkeys/monkeys-identity/internal/database"
 	"github.com/the-monkeys/monkeys-identity/internal/models"
+	"github.com/the-monkeys/monkeys-identity/pkg/logger"
 )
 
 // DBTX interface for both *sql.DB and *sql.Tx
@@ -79,22 +80,23 @@ type ResourceAccessLog struct {
 }
 
 type resourceQueries struct {
-	db    *database.DB
-	redis *redis.Client
-	tx    *sql.Tx
-	ctx   context.Context
+	db     *database.DB
+	redis  *redis.Client
+	logger *logger.Logger
+	tx     *sql.Tx
+	ctx    context.Context
 }
 
-func NewResourceQueries(db *database.DB, redis *redis.Client) ResourceQueries {
-	return &resourceQueries{db: db, redis: redis, ctx: context.Background()}
+func NewResourceQueries(db *database.DB, redis *redis.Client, logger *logger.Logger) ResourceQueries {
+	return &resourceQueries{db: db, redis: redis, logger: logger, ctx: context.Background()}
 }
 
 func (q *resourceQueries) WithTx(tx *sql.Tx) ResourceQueries {
-	return &resourceQueries{db: q.db, redis: q.redis, tx: tx, ctx: q.ctx}
+	return &resourceQueries{db: q.db, redis: q.redis, logger: q.logger, tx: tx, ctx: q.ctx}
 }
 
 func (q *resourceQueries) WithContext(ctx context.Context) ResourceQueries {
-	return &resourceQueries{db: q.db, redis: q.redis, tx: q.tx, ctx: ctx}
+	return &resourceQueries{db: q.db, redis: q.redis, logger: q.logger, tx: q.tx, ctx: ctx}
 }
 
 func (q *resourceQueries) ListResources(params ListParams, organizationID string) (*ListResult[*models.Resource], error) {

--- a/internal/queries/role.go
+++ b/internal/queries/role.go
@@ -9,6 +9,7 @@ import (
 	"github.com/redis/go-redis/v9"
 	"github.com/the-monkeys/monkeys-identity/internal/database"
 	"github.com/the-monkeys/monkeys-identity/internal/models"
+	"github.com/the-monkeys/monkeys-identity/pkg/logger"
 )
 
 // RoleQueries defines all role management database operations
@@ -38,22 +39,23 @@ type RoleQueries interface {
 }
 
 type roleQueries struct {
-	db    *database.DB
-	redis *redis.Client
-	tx    *sql.Tx
-	ctx   context.Context
+	db     *database.DB
+	redis  *redis.Client
+	logger *logger.Logger
+	tx     *sql.Tx
+	ctx    context.Context
 }
 
-func NewRoleQueries(db *database.DB, redis *redis.Client) RoleQueries {
-	return &roleQueries{db: db, redis: redis, ctx: context.Background()}
+func NewRoleQueries(db *database.DB, redis *redis.Client, logger *logger.Logger) RoleQueries {
+	return &roleQueries{db: db, redis: redis, logger: logger, ctx: context.Background()}
 }
 
 func (q *roleQueries) WithTx(tx *sql.Tx) RoleQueries {
-	return &roleQueries{db: q.db, redis: q.redis, tx: tx, ctx: q.ctx}
+	return &roleQueries{db: q.db, redis: q.redis, logger: q.logger, tx: tx, ctx: q.ctx}
 }
 
 func (q *roleQueries) WithContext(ctx context.Context) RoleQueries {
-	return &roleQueries{db: q.db, redis: q.redis, tx: q.tx, ctx: ctx}
+	return &roleQueries{db: q.db, redis: q.redis, logger: q.logger, tx: q.tx, ctx: ctx}
 }
 
 // Role-specific query methods

--- a/internal/queries/session_queries.go
+++ b/internal/queries/session_queries.go
@@ -10,6 +10,7 @@ import (
 	"github.com/redis/go-redis/v9"
 	"github.com/the-monkeys/monkeys-identity/internal/database"
 	"github.com/the-monkeys/monkeys-identity/internal/models"
+	"github.com/the-monkeys/monkeys-identity/pkg/logger"
 )
 
 // SessionQueries defines all session management database operations
@@ -70,22 +71,23 @@ type SessionActivity struct {
 }
 
 type sessionQueries struct {
-	db    *database.DB
-	redis *redis.Client
-	tx    *sql.Tx
-	ctx   context.Context
+	db     *database.DB
+	redis  *redis.Client
+	logger *logger.Logger
+	tx     *sql.Tx
+	ctx    context.Context
 }
 
-func NewSessionQueries(db *database.DB, redis *redis.Client) SessionQueries {
-	return &sessionQueries{db: db, redis: redis, ctx: context.Background()}
+func NewSessionQueries(db *database.DB, redis *redis.Client, logger *logger.Logger) SessionQueries {
+	return &sessionQueries{db: db, redis: redis, logger: logger, ctx: context.Background()}
 }
 
 func (q *sessionQueries) WithTx(tx *sql.Tx) SessionQueries {
-	return &sessionQueries{db: q.db, redis: q.redis, tx: tx, ctx: q.ctx}
+	return &sessionQueries{db: q.db, redis: q.redis, logger: q.logger, tx: tx, ctx: q.ctx}
 }
 
 func (q *sessionQueries) WithContext(ctx context.Context) SessionQueries {
-	return &sessionQueries{db: q.db, redis: q.redis, tx: q.tx, ctx: ctx}
+	return &sessionQueries{db: q.db, redis: q.redis, logger: q.logger, tx: q.tx, ctx: ctx}
 }
 
 func (q *sessionQueries) CreateSession(session *models.Session) error {
@@ -120,7 +122,7 @@ func (q *sessionQueries) CreateSession(session *models.Session) error {
 		err = q.cacheSession(session)
 		if err != nil {
 			// Log error but don't fail the operation
-			// TODO: Add proper logging
+			q.logger.Error("Failed to cache session in Redis: %v", err)
 		}
 	}
 
@@ -250,7 +252,9 @@ func (q *sessionQueries) UpdateSession(session *models.Session, organizationID s
 
 	// Update cache
 	if q.redis != nil {
-		q.cacheSession(session)
+		if err := q.cacheSession(session); err != nil {
+			q.logger.Error("Failed to update session cache in Redis: %v", err)
+		}
 	}
 
 	return nil
@@ -280,7 +284,9 @@ func (q *sessionQueries) DeleteSession(sessionID, organizationID string) error {
 
 	// Remove from cache
 	if q.redis != nil {
-		q.removeCachedSession(sessionID)
+		if err := q.removeCachedSession(sessionID); err != nil {
+			q.logger.Error("Failed to remove session from Redis cache: %v", err)
+		}
 	}
 
 	return nil
@@ -460,7 +466,9 @@ func (q *sessionQueries) ExtendSession(sessionID, organizationID string, newExpi
 		if session, err := q.GetSession(sessionID, organizationID); err == nil {
 			session.ExpiresAt = newExpiresAt
 			session.LastUsedAt = time.Now()
-			q.cacheSession(session)
+			if err := q.cacheSession(session); err != nil {
+				q.logger.Error("Failed to update session cache in Redis during extension: %v", err)
+			}
 		}
 	}
 
@@ -491,7 +499,9 @@ func (q *sessionQueries) RevokeSession(sessionID, organizationID string) error {
 
 	// Remove from cache
 	if q.redis != nil {
-		q.removeCachedSession(sessionID)
+		if err := q.removeCachedSession(sessionID); err != nil {
+			q.logger.Error("Failed to remove session from Redis cache during revocation: %v", err)
+		}
 	}
 
 	return nil
@@ -519,7 +529,9 @@ func (q *sessionQueries) RevokeAllUserSessions(userID, organizationID string) er
 	if q.redis != nil && rows > 0 {
 		sessions, _ := q.ListUserSessions(userID, organizationID)
 		for _, session := range sessions {
-			q.removeCachedSession(session.ID)
+			if err := q.removeCachedSession(session.ID); err != nil {
+				q.logger.Error("Failed to remove session %s from Redis cache during bulk revocation: %v", session.ID, err)
+			}
 		}
 	}
 

--- a/internal/queries/user.go
+++ b/internal/queries/user.go
@@ -10,6 +10,7 @@ import (
 	"github.com/redis/go-redis/v9"
 	"github.com/the-monkeys/monkeys-identity/internal/database"
 	"github.com/the-monkeys/monkeys-identity/internal/models"
+	"github.com/the-monkeys/monkeys-identity/pkg/logger"
 )
 
 // UserQueries defines all user management database operations
@@ -53,38 +54,42 @@ type UserQueries interface {
 
 // userQueries implements UserQueries
 type userQueries struct {
-	db    *database.DB
-	redis *redis.Client
-	tx    *sql.Tx
-	ctx   context.Context
+	db     *database.DB
+	redis  *redis.Client
+	logger *logger.Logger
+	tx     *sql.Tx
+	ctx    context.Context
 }
 
 // NewUserQueries creates a new UserQueries instance
-func NewUserQueries(db *database.DB, redis *redis.Client) UserQueries {
+func NewUserQueries(db *database.DB, redis *redis.Client, logger *logger.Logger) UserQueries {
 	return &userQueries{
-		db:    db,
-		redis: redis,
-		ctx:   context.Background(),
+		db:     db,
+		redis:  redis,
+		logger: logger,
+		ctx:    context.Background(),
 	}
 }
 
 // WithTx returns a new UserQueries instance that will run all SQL queries within a transaction
 func (q *userQueries) WithTx(tx *sql.Tx) UserQueries {
 	return &userQueries{
-		db:    q.db,
-		redis: q.redis,
-		tx:    tx,
-		ctx:   q.ctx,
+		db:     q.db,
+		redis:  q.redis,
+		logger: q.logger,
+		tx:     tx,
+		ctx:    q.ctx,
 	}
 }
 
 // WithContext returns a new UserQueries instance with context
 func (q *userQueries) WithContext(ctx context.Context) UserQueries {
 	return &userQueries{
-		db:    q.db,
-		redis: q.redis,
-		tx:    q.tx,
-		ctx:   ctx,
+		db:     q.db,
+		redis:  q.redis,
+		logger: q.logger,
+		tx:     q.tx,
+		ctx:    ctx,
 	}
 }
 

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -72,7 +72,7 @@ func SetupRoutes(
 	tenantMw := middleware.NewTenantMiddleware(systemOrgID)
 
 	// Initialize queries
-	q := queries.New(db, redis)
+	q := queries.New(db, redis, logger)
 
 	// Initialize services
 	authzSvc := services.NewAuthzService(q)
@@ -95,7 +95,7 @@ func SetupRoutes(
 	contentHandler := handlers.NewContentHandler(db, redis, logger)
 
 	// Create queries instance for audit handler
-	auditQueries := queries.New(db, redis)
+	auditQueries := queries.New(db, redis, logger)
 	auditHandler := handlers.NewAuditHandler(auditQueries, logger, auditService)
 
 	// Global API Rate Limiting


### PR DESCRIPTION
Implemented logging for Redis cache operations within the session query layer. This involved refactoring the entire query package to support dependency injection of the application's logger.

Changes:
- Added logger support to all query implementations in `internal/queries/`.
- Updated `Queries` struct and constructors to accept and propagate the logger.
- Implemented error logging for Redis failures in `CreateSession`, `UpdateSession`, `ExtendSession`, and `RevokeSession`.
- Updated handlers, routes, and main entry points to provide the logger to the query layer.
- Removed the "TODO: Add proper logging" from `session_queries.go`.